### PR TITLE
Please pull: Fix ampersand problem and remove unnecessary script

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## syntax highlighting
 
-* write your code in <pre> tags
+* write your code in &lt;pre&gt; tags
 * or in plain markdown syntax (see below)
 * annotate the given language using a css class
 

--- a/README.md
+++ b/README.md
@@ -22,12 +22,19 @@
 
 ## syntax highlighting
 
-* write your code in &lt;pre&gt; tags or with plain markdown syntax
+* write your code in <pre> tags
+* or in plain markdown syntax (see below)
 * annotate the given language using a css class
 
-    &lt;pre class="syntax c"&gt;
+    <pre class="syntax c">
     static int foo;
     void bar(void) {
         foo = 0;
         while (foo != 255) ; }
-    &lt;/pre&gt;
+    </pre>
+
+* if you want to syntax highlight *all* your code in the same way
+  then you can uncomment and customize the following line at the
+  bottom of the presentation.html file:
+
+        $('pre > code').parent().addClass("syntax cpp");

--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@
 * or in plain markdown syntax (see below)
 * annotate the given language using a css class
 
-    <pre class="syntax c">
-    static int foo;
-    void bar(void) {
-        foo = 0;
-        while (foo != 255) ; }
-    </pre>
+        <pre class="syntax c">
+        static int foo;
+        void bar(void) {
+            foo = 0;
+            while (foo != 255) ; }
+        </pre>
 
 * if you want to syntax highlight *all* your code in the same way
   then you can uncomment and customize the following line at the

--- a/README.md
+++ b/README.md
@@ -19,3 +19,15 @@
 * if need be, print the document to pdf
  * slides will automatically get separated into pages
  * styling will keep intact
+
+## syntax highlighting
+
+* write your code in &lt;pre&gt; tags or with plain markdown syntax
+* annotate the given language using a css class
+
+    &lt;pre class="syntax c"&gt;
+    static int foo;
+    void bar(void) {
+        foo = 0;
+        while (foo != 255) ; }
+    &lt;/pre&gt;

--- a/presentation.html
+++ b/presentation.html
@@ -44,6 +44,7 @@
 # syntax highlighting
 
 * write your code in &lt;pre&gt; tags 
+* or in plain markdown syntax (see below)
 * annotate the given language using a css class
 
 <pre>
@@ -62,6 +63,15 @@ void bar(void) {
     while (foo != 255) ; }
 </pre>
 
+
+* if you want to syntax highlight *all* your code in the same way
+  then you can uncomment and customize the following line at the
+  bottom of the presentation.html file:
+
+<pre>
+$('pre &gt; code').parent().addClass("syntax cpp");
+</pre>
+
 </script>
 
 <script>
@@ -72,6 +82,10 @@ void bar(void) {
     document.write('<div class=slide>' + slides[j] + '</div>');
   });
   $(".presentation").remove();
+  // if you want to syntax highlight *all* your code in the same way
+  // then you can uncomment and customize the next line
+  //
+  //$("pre>code").parent().addClass("syntax cpp");
   w3c_slidy.add_listener(document.body, "touchend", w3c_slidy.mouse_button_click);
   $.syntax(); 
 </script>

--- a/presentation.html
+++ b/presentation.html
@@ -66,7 +66,7 @@ void bar(void) {
 
 <script>
   $(".presentation").each(function() {
-    var markup = new Showdown.converter().makeHtml($(this).text());
+    var markup = new Showdown.converter().makeHtml($(this).html());
     var slides = markup.split('<hr />');
     for (var j = 0; j < slides.length; j++)
     document.write('<div class=slide>' + slides[j] + '</div>');

--- a/presentation.html
+++ b/presentation.html
@@ -66,7 +66,7 @@ void bar(void) {
 
 <script>
   $(".presentation").each(function() {
-    var markup = new Showdown.converter().makeHtml($(this).html());
+    var markup = new Showdown.converter().makeHtml($(this).text());
     var slides = markup.split('<hr />');
     for (var j = 0; j < slides.length; j++)
     document.write('<div class=slide>' + slides[j] + '</div>');

--- a/presentation.html
+++ b/presentation.html
@@ -10,7 +10,6 @@
     <script src="slidy.js"></script>
     <script src="jquery-syntax/jquery-1.4.4.min.js"></script>
     <script src="jquery-syntax/jquery.syntax.min.js"></script>
-    <script src="p-slides.js"></script>
 </head>
 <body>
 

--- a/presentation.html
+++ b/presentation.html
@@ -13,7 +13,7 @@
 </head>
 <body>
 
-<code class="presentation">
+<script type="p_slides" class="presentation">
 
 # p_slides
 ## dead simple way to create semantic, nice to look at slides
@@ -62,7 +62,7 @@ void bar(void) {
     while (foo != 255) ; }
 </pre>
 
-</code>
+</script>
 
 <script>
   $(".presentation").each(function() {

--- a/style.css
+++ b/style.css
@@ -1,3 +1,14 @@
 .syntax-container { font-size: 17px; }
 
 h2, h3 { margin-bottom: 0.8em !important; }
+
+
+/* Inline code can occur on every level of a list and
+ * inside p's, thus it should be adapted to the elements
+ * font size. twitter_bootstrap.css wants to set a fixed
+ * size for code though. Thus we override it here and
+ * inherit from the parent.
+ */
+body code {
+	font-size: 80%;
+}

--- a/style.css
+++ b/style.css
@@ -15,6 +15,15 @@ body code {
 
 /* the following concerns code _listings_
  */
+.syntax-container.syntax-theme-base ol.syntax.highlighted {
+        /* The padding of the line numbers provided by
+	 * jquery.syntax.layout.list.css is too large.
+	 * Override and reduce the padding to ca. 2 digits
+	 * since the purpose of p_slides is presentations
+	 * and as such 3 digit line numbers will not occur.
+	 */
+	padding-left: 2em !important;
+}
 .syntax-container.syntax-theme-base ol.syntax.highlighted li {
         /* Font size is set by twitter_bootstrap.css or by
 	 * slidy.css to 100% and thus varies with the list

--- a/style.css
+++ b/style.css
@@ -12,3 +12,14 @@ h2, h3 { margin-bottom: 0.8em !important; }
 body code {
 	font-size: 80%;
 }
+
+/* the following concerns code _listings_
+ */
+.syntax-container.syntax-theme-base ol.syntax.highlighted li {
+        /* Font size is set by twitter_bootstrap.css or by
+	 * slidy.css to 100% and thus varies with the list
+	 * level we're in. We want to have constant code listing
+	 * font sizes.
+	 */
+	font-size: 10px;
+}


### PR DESCRIPTION
Please have a look at the latest commit https://github.com/tpo/p_slides/commit/b97b7d13c7f742e7323c596ea40332b3c3563eed and let your mind assimilate it.

So the proposed solution is a rather extravagant hack, however it seems quite clean. One thing I don't know is what browsers are allowed to do when they see a tag like this:

```
<script type="p_slides"
```

Are they allowed to just drop the element from the DOM tree? That would prevent p_sides to work on such a browser. Or are the browsers supposed to just ignore that element but still put it into the DOM? That would be good. If browsers would however complain about an unknow script type, that wouldn't be nice.

Overal I think this solution shoul work. Please pull :-)
*t  
